### PR TITLE
Security hardening: answer authorization, cookies, and URL parsing

### DIFF
--- a/app/_actions/process-answer.ts
+++ b/app/_actions/process-answer.ts
@@ -8,18 +8,33 @@ import {
   STEP,
   validateRouteParam,
 } from '@lib/server'
-import { headers } from 'next/headers'
+import { cookies, headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import z from 'zod'
 
 // Local helper instead of importing from `next/dist/...`, which is a private
 // internal path with no stability guarantee across Next.js releases.
-const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+const wait = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms)
+  })
+
+// The referer header is client-controlled and may be missing entirely
+// (strict referrer policies, direct POSTs), so parse it defensively.
+function getStepFromReferer(referer: string | null): string | undefined {
+  if (!referer) {
+    return undefined
+  }
+  try {
+    return new URL(referer).pathname.split('/').at(-1)
+  } catch {
+    return undefined
+  }
+}
 
 export async function processAnswer(formData: FormData) {
   const headersList = await headers()
-  const referer = headersList.get('referer') as string
-  const step = new URL(referer).pathname.split('/').at(-1)
+  const step = getStepFromReferer(headersList.get('referer'))
   const answer = formData.get('answer') as string
 
   if (!step || !answer) {
@@ -28,6 +43,16 @@ export async function processAnswer(formData: FormData) {
   }
 
   const currentStep = validateRouteParam(step, z.coerce.number())
+
+  // Authorize the submitted step against the trusted httpOnly cookie (the
+  // source of truth the proxy also enforces), so a spoofed referer cannot
+  // process an answer for an arbitrary step. Step 1 has no cookie yet.
+  const cookieStep = (await cookies()).get(STEP)?.value
+  if (currentStep !== 1 && String(currentStep) !== cookieStep) {
+    await deleteCookie(STEP)
+    redirect('/')
+  }
+
   const prevStep = currentStep - 1
   const nextStep = currentStep + 1
   const quizList = await getQuizList()

--- a/app/_lib/server/cookies.ts
+++ b/app/_lib/server/cookies.ts
@@ -8,6 +8,9 @@ export async function setCookie(key: string, value: number): Promise<void> {
   cookieStore.set(key, JSON.stringify(value), {
     expires: Date.now() + ONE_HOUR,
     httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
   })
 }
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -3,7 +3,9 @@ import { NextRequest, NextResponse } from 'next/server'
 
 export function proxy(request: NextRequest) {
   const stepFromCookie = request.cookies.get(STEP)?.value
-  const stepFromUrl = request.url.split('/').at(-1)
+  // Use the parsed pathname so query strings / trailing slashes don't corrupt
+  // the extracted step (e.g. `/quiz/3?x=1` -> `3`, not `3?x=1`).
+  const stepFromUrl = request.nextUrl.pathname.split('/').at(-1)
 
   if (stepFromUrl === '1') {
     return NextResponse.next()


### PR DESCRIPTION
Follow-up to #207. Addresses security/robustness findings from the Next.js best-practices review.

## Changes

### 1. Harden server action authorization (`app/_actions/process-answer.ts`)
- The current step was derived entirely from the client-controlled `referer` header (cast `as string`), which could **crash** the action (`new URL(undefined)`) when the header is missing, and allowed a crafted request to process an answer for an **arbitrary step**.
- Now parses the referer defensively (no throw when missing/invalid) and **authorizes the submitted step against the trusted `httpOnly` STEP cookie** — the same source of truth the proxy enforces. Step 1 legitimately has no cookie yet.

### 2. Cookie hardening (`app/_lib/server/cookies.ts`)
- Added `sameSite: 'lax'`, `secure` (in production), and `path: '/'` to the STEP cookie for CSRF/transport hardening.

### 3. Robust proxy URL parsing (`proxy.ts`)
- Switched from `request.url.split('/')` to `request.nextUrl.pathname.split('/')` so query strings and trailing slashes (e.g. `/quiz/3?x=1`) no longer corrupt the extracted step.

## Verification
- Lint (oxlint) and Prettier pass via pre-commit hooks.
- `/` and `/quiz/1` return 200 in the dev server.

Co-authored-by: v0 <it+v0agent@vercel.com>